### PR TITLE
Etl enhancement

### DIFF
--- a/src/Entity/ImportableTrait.php
+++ b/src/Entity/ImportableTrait.php
@@ -13,7 +13,7 @@ trait ImportableTrait
      * Store id for remote source, use this as identifiant to make reference in import scripts.
      * @var string
      *
-     * @ORM\Column(type="string", length=100, nullable=true)
+     * @ORM\Column(type="string", length=100, nullable=true, unique=true)
      */
     protected $importId;
 

--- a/src/Exception/Extractor/EntityIdentifierAlreadyProcessedException.php
+++ b/src/Exception/Extractor/EntityIdentifierAlreadyProcessedException.php
@@ -12,5 +12,5 @@ class EntityIdentifierAlreadyProcessedException extends ExtractException
     /**
      * @inheritdoc
      */
-    protected $message = 'EXTRACTOR : Entity type "%s" already registered';
+    protected $message = 'EXTRACTOR : Entity with identifier "%s" already processed';
 }

--- a/src/Extractor/EntityFileExtractorTrait.php
+++ b/src/Extractor/EntityFileExtractorTrait.php
@@ -182,6 +182,10 @@ trait EntityFileExtractorTrait
         $filepath = sprintf('%s/%s.' . $this->getFileExtension(), $this->folderToExtract, $filename);
 
         $data = $this->extractFileContent($filepath);
+        if ($data === null) {
+            return;
+        }
+
         foreach ($data as $values) {
             if ($values === null) {
                 continue;

--- a/tests/Extractor/AbstractEntityExtractorTest.php
+++ b/tests/Extractor/AbstractEntityExtractorTest.php
@@ -83,6 +83,7 @@ abstract class AbstractEntityExtractorTest extends TestCase
             })
         ;
         $entities = $extractor->extract();
+        $this->assertEquals([], $entities);
     }
 
     /**

--- a/tests/Extractor/AbstractEntityExtractorTest.php
+++ b/tests/Extractor/AbstractEntityExtractorTest.php
@@ -74,6 +74,20 @@ abstract class AbstractEntityExtractorTest extends TestCase
     /**
      * @throws \Exception
      */
+    public function testExtractNullContent()
+    {
+        $extractor = $this->getExtractor();
+        $extractor
+            ->addEntityToProcess('dummy', Project::class, function ($e) {
+                return $e->getCode();
+            })
+        ;
+        $entities = $extractor->extract();
+    }
+
+    /**
+     * @throws \Exception
+     */
     public function testExtractEntities()
     {
         $extractor = $this->getExtractor();


### PR DESCRIPTION
## Description

This PR fix some cases encounter during ETL integration on the TARO project.

**About the Extract**

First fix on EntityFileExtractorTrait.php prevent the foreach to fail if the data is null. I over type it with (array).
Second fix is about the EntityIdentifierAlreadyProcessedException feedback message that was the same as EntityAlreadyRegisteredException. I change it to be more accurate with the exception name.

**About the Loading**

During testing we find that the importId must be unique to ensure that the data will not be override by another during the extract phase (thus ensure than the import phase work as expected)

@nicolas-bastien if you could make a release for this after merge, that be nice ;)